### PR TITLE
Added Docker Compose files to deploy applications to Azure Web App (MOVECLOUD-T002 Solution)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,15 @@
 version: "3.4"
 services:
   api:
-    image: ghcr.io/mkloos-insight/fabrikam-api:latest
-    environment:
-      MONGODB_CONNECTION: mongodb://mongo:27017/contentdb
+    image: ghcr.io/<yourgithubaccount>/fabrikam-api:latest
     ports:
       - "3001:3001"
 
   web:
-    image: ghcr.io/mkloos-insight/fabrikam-web:latest
+    image: ghcr.io/<yourgithubaccount>/fabrikam-web:latest
     depends_on:
         - api
     environment:
         CONTENT_API_URL: http://api:3001
     ports:
-        - "3000:80"   
+        - "3000:80"       


### PR DESCRIPTION


# Instructions to Fix the exercise
Added a new docker-compose file (docker-compose) to configure the multi-container web application. To deploy this file, update the name of the container registry and change the CosmosDB connection string

```powershell
$studentprefix = "your abbreviation here"
$resourcegroupName = "fabmedical-rg-" + $studentprefix
$webappName = "fabmedical-web-" + $studentprefix

$ghpat=Read-Host -Prompt "Github Personal Access Token"

az webapp config container set `
--docker-registry-server-password $ghpat `
--docker-registry-server-url https://ghcr.io `
--docker-registry-server-user notapplicable `
--multicontainer-config-file docker-compose-prod.yml `
--multicontainer-config-type COMPOSE `
--name $webappName `
--resource-group $resourcegroupName 
```

Linked to [AB#12](https://dev.azure.com/MichaelKloos/2f75891c-6579-4e80-a315-fda264be0432/_workitems/edit/12)